### PR TITLE
Add Shift+Tab Navigation for Autocomplete Suggestions

### DIFF
--- a/src/cli_core.rs
+++ b/src/cli_core.rs
@@ -735,6 +735,13 @@ impl CliCore {
                 ReedlineEvent::MenuNext,
             ]),
         );
+        
+        // Add Shift+Tab for navigating up through suggestions
+        keybindings.add_binding(
+            KeyModifiers::SHIFT,
+            KeyCode::BackTab,
+            ReedlineEvent::MenuPrevious,
+        );
 
         let edit_mode = Box::new(Emacs::new(keybindings));
 


### PR DESCRIPTION
# Add Shift+Tab Navigation for Autocomplete Suggestions

  ## Summary

  - Adds bidirectional navigation for autocomplete suggestions
  - **Tab**: Navigate down through suggestions (existing behavior)
  - **Shift+Tab**: Navigate up through suggestions (new feature)
  - Improves user experience for SQL autocomplete workflow

  ## Technical Details

  - Uses `KeyCode::BackTab` with `KeyModifiers::SHIFT` for proper terminal compatibility
  - Implements `ReedlineEvent::MenuPrevious` for reverse menu navigation
  - Follows reedline library best practices as demonstrated in official examples
  - Minimal change: only 7 lines added to `src/cli_core.rs`

  ## Testing

  ```bash
  # Build and test
  cargo build --release
  cargo run --release -- postgres://your_connection

  # In the REPL, test navigation:
  postgres@mydb=> SELECT * FROM users[TAB]      # Cycles down through suggestions
  postgres@mydb=> SELECT * FROM users[SHIFT+TAB] # Cycles up through suggestions
  ```

  ## Files Changed

  - `src/cli_core.rs`: Added Shift+Tab keybinding for reverse autocomplete navigation

  ## Backward Compatibility

  - ✅ No breaking changes
  - ✅ Existing Tab behavior unchanged
  - ✅ Pure additive feature